### PR TITLE
Removed absolute paths and hard-coded usage of port 8088

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -171,8 +171,7 @@ export default function App(props) {
 	const [value, setValue] = React.useState('recents');
 	const [darkMode, setDarkMode] = useLocalStorage('cedalo.managementcenter.darkMode');
 
-	// TODO: make URL relative
-	const [response, loading, hasError] = useFetch(`http://${window.location.hostname}:8088/api/theme`);
+	const [response, loading, hasError] = useFetch(`/api/theme`);
 
 	if (hasError || response) {
 		let appliedTheme = darkMode === 'true' ? darkTheme : customTheme;

--- a/frontend/src/components/InfoPage.js
+++ b/frontend/src/components/InfoPage.js
@@ -63,7 +63,7 @@ const getPremium = () => {
 const InfoPage = (props) => {
 	const classes = useStyles();
 	const [open, setOpen] = React.useState(false);
-	const [response, loading, hasError] = useFetch(`http://${window.location.hostname}:8088/api/update`);
+	const [response, loading, hasError] = useFetch(`/api/update`);
 	const { license, version, webSocketConnections } = props;
 
 	const handleClickOpen = () => {
@@ -266,7 +266,7 @@ const InfoPage = (props) => {
 				)}
 
 				<br />
-				{license?.features && 
+				{license?.features &&
 					<TableContainer component={Paper} className={classes.tableContainer}>
 						<Table size="medium">
 							<TableHead>

--- a/frontend/src/components/NewsletterPopup.js
+++ b/frontend/src/components/NewsletterPopup.js
@@ -33,7 +33,7 @@ const NewsletterPopup = () => {
 
 	const subscribeNewsletter = async (email) => {
 		try {
-			const response = await fetch(`http://${window.location.hostname}:8088/api/newsletter/subscribe`, {
+			const response = await fetch(`/api/newsletter/subscribe`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'
@@ -76,7 +76,7 @@ const NewsletterPopup = () => {
 					setShowNewsletterPopup('false');
 				  }
 			}
-		  
+
 		}, NEWSLETTER_POPUP_DELAY);
 		return () => clearTimeout(timer);
 	  }, []);

--- a/frontend/src/components/OnBoardingDialog.js
+++ b/frontend/src/components/OnBoardingDialog.js
@@ -188,7 +188,7 @@ const OnBoardingDialog = ({ settings }) => {
 
 	const subscribeNewsletter = async () => {
 		try {
-			const response = await fetch(`http://${window.location.hostname}:8088/api/newsletter/subscribe`, {
+			const response = await fetch(`/api/newsletter/subscribe`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'

--- a/frontend/src/components/Plugins.js
+++ b/frontend/src/components/Plugins.js
@@ -43,7 +43,7 @@ const Plugins = (props) => {
 	const dispatch = useDispatch();
 	const confirm = useConfirm();
 	const { client } = context;
-	const [response, loading, hasError] = useFetch(`http://${window.location.hostname}:8088/api/plugins`);
+	const [response, loading, hasError] = useFetch(`/api/plugins`);
 
 	const handlePluginLoad = async (pluginId, load) => {
 		if (load) {

--- a/frontend/src/components/Streamsheets.js
+++ b/frontend/src/components/Streamsheets.js
@@ -67,7 +67,7 @@ const Streamsheets = (props) => {
 
 	const { client } = context;
 	const [response, loading, hasError] = useFetch(
-		`http://${window.location.hostname}:8088/api/config/tools/streamsheets`
+		`/api/config/tools/streamsheets`
 	);
 
 	const onPreviewInstance = async (instance) => {

--- a/frontend/src/websockets/config.js
+++ b/frontend/src/websockets/config.js
@@ -1,5 +1,4 @@
 export default {
-	// TODO: make configurable
-	url: `ws://${window.location.hostname}:8088`
+	url: `ws://${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`
 	// url: 'ws://192.168.178.52:8088'
 };


### PR DESCRIPTION
This pull request is to address issue #18. However, instead of making the port configurable, I used relative paths where possible. In one case (frontend/src/websockets/config.js ), I had to use window.location.port to check what the port is.