### PR TITLE
Problem with uuid/v1

### DIFF
--- a/frontend/src/client/BaseMosquittoProxyClient.js
+++ b/frontend/src/client/BaseMosquittoProxyClient.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid/v1');
+const { v1: uuid } = require('uuid');
 
 const createError = (code, message) => ({
 	code,


### PR DESCRIPTION
The file frontend/src/client/BaseMosquittoProxyClient.js has:

const uuid = require('uuid/v1');

During the `yarn workspace @cedalo/management-center-frontend run build` this fails. The
file backend/src/client/BaseMosquittoClient.js has the following:

const { v1: uuid } = require('uuid');

Using this fixes the error.