### PR TITLE
Feature/os agnostic frontend scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,12 @@
 	"scripts": {
 		"start": "react-scripts start",
 		"build": "react-scripts build",
-		"build-without-base-path": "rm -rf ../backend/public && cross-env PUBLIC_URL=/ react-scripts build && mv build ../backend/public",
-		"build-with-base-path": "cross-env PUBLIC_URL=/mosquitto-management-center react-scripts build && mv build ../backend/public",
+		"build-without-base-path": "run-script-os",
+		"build-without-base-path:win32": "(if exist ..\\backend\\public rmdir ..\\backend\\public /s /q) && cross-env PUBLIC_URL=/ react-scripts build && move build ../backend/public",
+		"build-without-base-path:darwin:linux": "rm -rf ../backend/public && cross-env PUBLIC_URL=/ react-scripts build && mv build ../backend/public",
+		"build-with-base-path": "run-script-os",
+		"build-with-base-path:win32": "cross-env PUBLIC_URL=/mosquitto-management-center react-scripts build && move build ../backend/public",
+		"build-with-base-path:darwin:linux": "cross-env PUBLIC_URL=/mosquitto-management-center react-scripts build && mv build ../backend/public",
 		"test": "react-scripts test",
 		"test-client": "npx jest tests/client.test.js --detectOpenHandles",
 		"eject": "react-scripts eject",
@@ -43,7 +47,8 @@
 		"chart.js": "^2.9.3",
 		"clsx": "latest",
 		"cross-env": "^7.0.3",
-		"jest": "24"
+		"jest": "24",
+		"run-script-os": "^1.1.6"
 	},
 	"browserslist": {
 		"production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12592,6 +12592,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+run-script-os@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
+  integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
add os independent scripts: "build-without-base-path" and "build-with-base-path" in frontend/package.json